### PR TITLE
test and fix for decodeVariableLength bug

### DIFF
--- a/libnetty-fastcgi/src/main/java/com/github/fmjsjx/libnetty/fastcgi/FcgiCodecUtil.java
+++ b/libnetty-fastcgi/src/main/java/com/github/fmjsjx/libnetty/fastcgi/FcgiCodecUtil.java
@@ -91,7 +91,7 @@ class FcgiCodecUtil {
             in.skipBytes(1);
             return length;
         } else {
-            return in.readInt() & (1 << 31);
+            return in.readInt() & ((1 << 31) - 1);
         }
     }
 

--- a/libnetty-fastcgi/src/test/java/com/github/fmjsjx/libnetty/fastcgi/FcgiCodecUtilTest.java
+++ b/libnetty-fastcgi/src/test/java/com/github/fmjsjx/libnetty/fastcgi/FcgiCodecUtilTest.java
@@ -1,0 +1,29 @@
+package com.github.fmjsjx.libnetty.fastcgi;
+
+import io.netty.buffer.Unpooled;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.stream.IntStream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * unit tests for util functions
+ *
+ * @author eharman
+ * @since 2021-10-05
+ */
+public class FcgiCodecUtilTest
+{
+    @Test
+    void variableLengthIO() {
+        for (int i = 0; i < 2100; i++)
+        {
+            var buf = Unpooled.buffer();
+            FcgiCodecUtil.encodeVariableLength(i, buf);
+            var out = FcgiCodecUtil.decodeVariableLength(buf);
+            assertEquals(i, out);
+        }
+    }
+}


### PR DESCRIPTION
I found this bug while trying to use the fastcgi server side library.

Also ran with a test wrapper at https://github.com/edward3h/libnetty-fcgi-test