### PR TITLE
Upgrade dependencies

### DIFF
--- a/buildSrc/src/main/kotlin/libnetty.java-library-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/libnetty.java-library-conventions.gradle.kts
@@ -11,34 +11,33 @@ repositories {
 
 dependencies {
     // netty-bom
-    api(platform("io.netty:netty-bom:4.1.110.Final"))
+    api(platform("io.netty:netty-bom:4.1.114.Final"))
     // libcommon-bom
-    api(platform("com.github.fmjsjx:libcommon-bom:3.8.1"))
+    api(platform("com.github.fmjsjx:libcommon-bom:3.9.0"))
     // jackson2-bom
-    api(platform("com.fasterxml.jackson:jackson-bom:2.17.1"))
+    api(platform("com.fasterxml.jackson:jackson-bom:2.18.0"))
     // junit-bom
-    testImplementation(platform("org.junit:junit-bom:5.10.2"))
+    testImplementation(platform("org.junit:junit-bom:5.11.2"))
     // mockito
-    testImplementation(platform("org.mockito:mockito-bom:5.12.0"))
+    testImplementation(platform("org.mockito:mockito-bom:5.14.2"))
     // log4j2
-    implementation(platform("org.apache.logging.log4j:log4j-bom:2.23.1"))
+    implementation(platform("org.apache.logging.log4j:log4j-bom:2.24.1"))
     // kotlin coroutines
-    implementation(platform("org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.8.1"))
+    implementation(platform("org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.9.0"))
 
     constraints {
-        api("org.slf4j:slf4j-api:2.0.13")
-        val lombokVersion = "1.18.32"
+        api("org.slf4j:slf4j-api:2.0.16")
+        val lombokVersion = "1.18.34"
         compileOnly("org.projectlombok:lombok:$lombokVersion")
         annotationProcessor("org.projectlombok:lombok:$lombokVersion")
-        implementation("ch.qos.logback:logback-classic:1.5.6")
+        implementation("ch.qos.logback:logback-classic:1.5.9")
         implementation("com.jcraft:jzlib:1.1.3")
         implementation("org.brotli:dec:0.1.2")
         implementation("com.aayushatharva.brotli4j:brotli4j:1.16.0")
         val kotlinVersion = "1.9.0"
         implementation("org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion")
         implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlinVersion")
-        implementation("org.bouncycastle:bcpkix-jdk15to18:1.78.1")
-        val fastjson2Version = "2.0.50"
+        val fastjson2Version = "2.0.53"
         api("com.alibaba.fastjson2:fastjson2:$fastjson2Version")
         api("com.alibaba.fastjson2:fastjson2-kotlin:$fastjson2Version")
 	}

--- a/libnetty-example/build.gradle.kts
+++ b/libnetty-example/build.gradle.kts
@@ -32,7 +32,7 @@ dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-jdk8")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-reactor")
-    implementation("org.bouncycastle:bcpkix-jdk15to18")
+    implementation("org.bouncycastle:bcpkix-lts8on:2.73.6")
 
     testImplementation("org.junit.jupiter:junit-jupiter-api")
     testImplementation("org.mockito:mockito-core")


### PR DESCRIPTION
```
netty                4.1.110.Final > 4.1.114.Final
libcommon            3.8.1         > 3.9.0
jackson2             2.17.1        > 2.18.0
junit                5.10.2        > 5.11.2
mockito              5.12.0        > 5.14.2
lob4j                2.23.1        > 2.24.1
kotlinx-coroutines   1.8.1         > 1.9.0
slf4j                2.0.13        > 2.0.16
lombok               1.18.32       > 1.18.34
fastjson2            2.0.50        > 2.0.53
```