### PR TITLE
Upgrade dependencies

### DIFF
--- a/buildSrc/src/main/kotlin/libnetty.java-library-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/libnetty.java-library-conventions.gradle.kts
@@ -11,29 +11,29 @@ repositories {
 
 dependencies {
     // netty-bom
-    api(platform("io.netty:netty-bom:4.1.114.Final"))
+    api(platform("io.netty:netty-bom:4.1.116.Final"))
     // libcommon-bom
-    api(platform("com.github.fmjsjx:libcommon-bom:3.9.1"))
+    api(platform("com.github.fmjsjx:libcommon-bom:3.10.0"))
     // jackson2-bom
-    api(platform("com.fasterxml.jackson:jackson-bom:2.18.0"))
+    api(platform("com.fasterxml.jackson:jackson-bom:2.18.2"))
     // junit-bom
-    testImplementation(platform("org.junit:junit-bom:5.11.2"))
+    testImplementation(platform("org.junit:junit-bom:5.11.4"))
     // mockito
     testImplementation(platform("org.mockito:mockito-bom:5.14.2"))
     // log4j2
-    implementation(platform("org.apache.logging.log4j:log4j-bom:2.24.1"))
+    implementation(platform("org.apache.logging.log4j:log4j-bom:2.24.3"))
     // kotlin coroutines
     implementation(platform("org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.9.0"))
 
     constraints {
         api("org.slf4j:slf4j-api:2.0.16")
-        val lombokVersion = "1.18.34"
+        val lombokVersion = "1.18.36"
         compileOnly("org.projectlombok:lombok:$lombokVersion")
         annotationProcessor("org.projectlombok:lombok:$lombokVersion")
-        implementation("ch.qos.logback:logback-classic:1.5.9")
+        implementation("ch.qos.logback:logback-classic:1.5.15")
         implementation("com.jcraft:jzlib:1.1.3")
         implementation("org.brotli:dec:0.1.2")
-        implementation("com.aayushatharva.brotli4j:brotli4j:1.16.0")
+        implementation("com.aayushatharva.brotli4j:brotli4j:1.18.0")
         val kotlinVersion = "1.9.0"
         implementation("org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion")
         implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlinVersion")


### PR DESCRIPTION
```
netty      4.1.114.Final > 4.1.116.Final
libcommon  3.9.1         > 3.10.0
jackson    2.18.0        > 2.18.2
junit      5.11.2        > 5.11.4
log4j      2.24.1        > 2.24.3
lombok     1.18.34       > 1.18.36
logback    1.5.9         > 1.5.15
brotli4j   1.16.0        > 1.18.0
```