### PR TITLE
Upgrade dependencies

### DIFF
--- a/buildSrc/src/main/kotlin/libnetty.java-library-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/libnetty.java-library-conventions.gradle.kts
@@ -11,17 +11,19 @@ repositories {
 
 dependencies {
     // netty-bom
-    api(platform("io.netty:netty-bom:4.2.6.Final"))
+    api(platform("io.netty:netty-bom:4.2.7.Final"))
     // libcommon-bom
-    api(platform("com.github.fmjsjx:libcommon-bom:3.16.1"))
+    api(platform("com.github.fmjsjx:libcommon-bom:3.17.0-RC1"))
     // jackson2-bom
-    api(platform("com.fasterxml.jackson:jackson-bom:2.20.0"))
+    api(platform("com.fasterxml.jackson:jackson-bom:2.20.1"))
+    // jackson3-bom
+    api(platform("tools.jackson:jackson-bom:3.0.3"))
     // junit-bom
-    testImplementation(platform("org.junit:junit-bom:5.13.4"))
+    testImplementation(platform("org.junit:junit-bom:6.0.1"))
     // mockito
-    testImplementation(platform("org.mockito:mockito-bom:5.19.0"))
+    testImplementation(platform("org.mockito:mockito-bom:5.20.0"))
     // log4j2
-    implementation(platform("org.apache.logging.log4j:log4j-bom:2.25.1"))
+    implementation(platform("org.apache.logging.log4j:log4j-bom:2.25.2"))
     // kotlin coroutines
     implementation(platform("org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.10.2"))
     // brotli4j
@@ -31,16 +33,16 @@ dependencies {
 
     constraints {
         api("org.slf4j:slf4j-api:2.0.17")
-        val lombokVersion = "1.18.40"
+        val lombokVersion = "1.18.42"
         compileOnly("org.projectlombok:lombok:$lombokVersion")
         annotationProcessor("org.projectlombok:lombok:$lombokVersion")
-        implementation("ch.qos.logback:logback-classic:1.5.18")
+        implementation("ch.qos.logback:logback-classic:1.5.21")
         implementation("com.jcraft:jzlib:1.1.3")
         implementation("org.brotli:dec:0.1.2")
-        val fastjson2Version = "2.0.58"
+        val fastjson2Version = "2.0.60"
         api("com.alibaba.fastjson2:fastjson2:$fastjson2Version")
         api("com.alibaba.fastjson2:fastjson2-kotlin:$fastjson2Version")
-        implementation("com.github.luben:zstd-jni:1.5.7-4")
+        implementation("com.github.luben:zstd-jni:1.5.7-6")
 	}
 
 }


### PR DESCRIPTION
```
netty       4.2.6.Final > 4.2.7.Final
libcommon   3.16.1      > 3.17.0-RC1
jackson2    2.20.0      > 2.20.1
jackson3    +3.0.3
junit       5.19.0      > 6.0.1
log4j       2.25.1      > 2.25.2
lombok      1.18.40     > 1.18.42
logback     1.5.18      > 1.5.21
fastjson2   2.0.58      > 2.0.60
zstd-jni    1.5.7-4     > 1.5.7-6
```