### PR TITLE
Upgrade Netty to 4.2.9.Final

### DIFF
--- a/buildSrc/src/main/kotlin/libnetty.java-library-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/libnetty.java-library-conventions.gradle.kts
@@ -11,7 +11,7 @@ repositories {
 
 dependencies {
     // netty-bom
-    api(platform("io.netty:netty-bom:4.2.7.Final"))
+    api(platform("io.netty:netty-bom:4.2.9.Final"))
     // libcommon-bom
     api(platform("com.github.fmjsjx:libcommon-bom:4.0.0-RC"))
     // jackson2-bom


### PR DESCRIPTION
Netty has a CRLF Injection vulnerability in `io.netty.handler.codec.http.HttpRequestEncoder`.

Upgrade to version 4.2.9.Final to fix this issue.

Also see: [CVE-2025-67735](https://www.mend.io/vulnerability-database/CVE-2025-67735)